### PR TITLE
added support for linux

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,67 @@
+# Stop at any error
+set -e
+
+export QTDIR=/usr/share/qt5/wrappers/
+export QTDIR=/usr/lib64/qt5
+# Location of the QT tools
+if [ -z ${QTDIR+x} ]; then
+	echo "QTDIR path not defined- please set it to the location containing the Qt version to build against. For example:"
+        echo "  export QTDIR=/Applications/Qt/5.10.0/clang_64"
+	exit 1
+fi
+
+QMAKE=${QTDIR}/bin/qmake
+MAKE=make
+
+# location of the source tree
+SOURCEDIR=`pwd`'/src'
+
+# Location to build PatternPaint
+BUILDDIR=`pwd`'/build_linux'
+
+
+################## Build JetiAppManager ###################
+mkdir -p ${BUILDDIR}
+pushd ${BUILDDIR}
+
+${QMAKE} ${SOURCEDIR}/JetiAppManager.pro \
+    -r \
+    -spec linux-g++ \
+    CONFIG+=console \
+    CONFIG+=x86_64
+
+#    CONFIG+=x86_64
+
+
+#${MAKE} clean
+${MAKE} -j6
+
+popd
+
+
+################## Package using macdeployqt #################
+pushd ${BUILDDIR}
+
+APP=${BUILDDIR}/JetiAppManager.app
+
+# Integrate the system frameworks
+${QTDIR}/bin/macdeployqt ${APP} -verbose=1
+
+
+################## make DMG #################
+
+DMG_NAME=JetiAppManager
+
+mkdir ${DMG_NAME}
+mv ${APP}/ ${DMG_NAME}/
+
+hdiutil create -volname ${DMG_NAME} -srcfolder ${DMG_NAME} -ov -format UDZO ${DMG_NAME}.dmg
+
+rm -R ${DMG_NAME}
+
+popd
+
+echo ""
+echo "#####################################"
+echo "JetiAppManager created successfully !"
+echo ""

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -80,8 +80,8 @@ bool AppManager::uninstallApp(Transmitter transmitter, QString appName)
 
             QString destPath;
             QString appFolderPath = TRANSMITTER_APPFOLDER;
-            #ifdef __APPLE__
-                // OSX path
+            #if defined(__APPLE__) || defined(__linux__)
+                // generic path
                 destPath = transmitter.rootPath + app.destinationPath[i];
                 appFolderPath = transmitter.rootPath + appFolderPath;
             #elif _WIN32
@@ -158,8 +158,8 @@ bool AppManager::isHttpRedirect(QNetworkReply *reply)
 bool AppManager::isTransmitterValid(QString rootpath)
 {
     QString destFile = TRANSMITTER_CONFIGFILE;
-    #ifdef __APPLE__
-        // OSX path
+    #if defined(__APPLE__) || defined(__linux__)
+        // generic path
         destFile = rootpath + destFile;
     #elif _WIN32
         // WIN path
@@ -178,8 +178,8 @@ bool AppManager::isTransmitterValid(QString rootpath)
 bool AppManager::isTransmitterSupportLua(QString rootpath)
 {
     QString destPath = TRANSMITTER_APPFOLDER;
-    #ifdef __APPLE__
-        // OSX path
+    #if defined(__APPLE__) || defined(__linux__)
+        // generic path
         destPath = rootpath + destPath;
     #elif _WIN32
         // WIN path
@@ -408,6 +408,7 @@ void AppManager::downloadFinished(QNetworkReply *reply)
 
                     emit(hasNewAppInformation());
                     emit(hasNewAppStatus());
+
                 }
 
             }else if(fileType == installSourcefile){
@@ -423,8 +424,8 @@ void AppManager::downloadFinished(QNetworkReply *reply)
 
                         if(sourceFileUrl == url && !transmitterList.isEmpty()){
                             QString destPath;
-                            #ifdef __APPLE__
-                                // OSX path
+                            #if defined(__APPLE__) || defined(__linux__)
+                                // generic path
                                 destPath = transmitterList[currentTransmitterIndex].rootPath + app.destinationPath[i] + "/";
                             #elif _WIN32
                                 // WIN path
@@ -564,8 +565,8 @@ bool AppManager::isAppInstalled(Transmitter transmitter, QString appName)
             QUrl url = QUrl::fromEncoded(sourceList[i].toLocal8Bit());
 
             QString destFile;
-            #ifdef __APPLE__
-                // OSX path
+            #if defined(__APPLE__) || defined(__linux__)
+                // generic path
                 destFile = transmitter.rootPath + app.destinationPath[i] + "/" + url.fileName();
             #elif _WIN32
                 // WIN path
@@ -603,8 +604,10 @@ void AppManager::checkAllAppsForUpdate(Transmitter transmitter)
                 QUrl url = QUrl::fromEncoded(sourceList[i].toLocal8Bit());
 
                 QString destFile;
-                #ifdef __APPLE__
-                    // OSX path
+                #if defined(__APPLE__) || defined(__linux__)
+                    // generic path
+                    destFile = transmitter.rootPath + app.destinationPath[i] + "/" + url.fileName();
+                #elif __linux__
                     destFile = transmitter.rootPath + app.destinationPath[i] + "/" + url.fileName();
                 #elif _WIN32
                     // WIN path

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -4,7 +4,7 @@
 #endif // DEFAULTS_H
 
 // Version
-#define JETIAPPMANAGER_VERSION          "V0.7 beta"
+#define JETIAPPMANAGER_VERSION          "V0.6"
 
 
 // Default settings
@@ -26,7 +26,7 @@
 
 
 // Font sizes
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__linux__)
     #define FONTSIZE_APP_DESCRIPTION    16
     #define FONTSIZE_APP_VERSION        10
     #define FONTSIZE_APP_AUTHOR         10

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -4,7 +4,7 @@
 #endif // DEFAULTS_H
 
 // Version
-#define JETIAPPMANAGER_VERSION          "V0.6"
+#define JETIAPPMANAGER_VERSION          "V0.7 beta"
 
 
 // Default settings

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@ int main(int argc, char *argv[])
 {
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
+    qRegisterMetaTypeStreamOperators<QList<QString>>("Data");
     QApplication a(argc, argv);
 
     a.setOrganizationName("Nightflyer88");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,9 @@ int main(int argc, char *argv[])
 {
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
+    // this is necessary for support of deserialization of the preference data for linux
+    // if this is missing an error message is given and no URLs are loaded:
+    // > QVariant::load: unknown user type with name QList<QString>
     qRegisterMetaTypeStreamOperators<QList<QString>>("Data");
     QApplication a(argc, argv);
 


### PR DESCRIPTION
Hi Nightflyer, while trying to use your JetAppManager I was not able to use it, because I have no macOS or Windows environment. So I forked your JetiAppManager and added support for Linux.
It was almost running without changes only build script and your OS specific coding has to be modified.
The only worth mentioning issue is in main.cpp. 
It is necessary for support of deserialization of the preference data for linux to do a
     qRegisterMetaTypeStreamOperators<QList<QString>>("Data");
before the QApplication is instantiated, to avoid the problem at startup:
  > QVariant::load: unknown user type with name QList<QString>

One of my reasons to use Jeti was the support of Linux (JETI-Studio), so maybe it is also meaningful for you to add Linux support to your JetiAppManager.

Regards

Rainer Stransky 